### PR TITLE
fix: source id format issue

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.7.1" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 

--- a/lib/screens/detail_screen.dart
+++ b/lib/screens/detail_screen.dart
@@ -35,6 +35,7 @@ class DetailScreen extends StatelessWidget {
             children: [
               WorkCover(
                 imageUrl: work.mainCoverUrl ?? '',
+                workId: work.id ?? 0,
                 sourceId: work.sourceId ?? '',
                 releaseDate: work.release,
               ),

--- a/lib/screens/detail_screen.dart
+++ b/lib/screens/detail_screen.dart
@@ -35,7 +35,7 @@ class DetailScreen extends StatelessWidget {
             children: [
               WorkCover(
                 imageUrl: work.mainCoverUrl ?? '',
-                rjNumber: work.sourceId ?? '',
+                sourceId: work.sourceId ?? '',
                 releaseDate: work.release,
               ),
               WorkInfo(work: work),

--- a/lib/screens/detail_screen.dart
+++ b/lib/screens/detail_screen.dart
@@ -26,7 +26,7 @@ class DetailScreen extends StatelessWidget {
       )..loadFiles(),
       child: Scaffold(
         appBar: AppBar(
-          title: Text('RJ${work.id ?? 0}'),
+          title: Text(work.sourceId ?? ''),
         ),
         body: SingleChildScrollView(
           padding: const EdgeInsets.only(bottom: MiniPlayer.height),
@@ -35,7 +35,7 @@ class DetailScreen extends StatelessWidget {
             children: [
               WorkCover(
                 imageUrl: work.mainCoverUrl ?? '',
-                rjNumber: 'RJ${work.id ?? 0}',
+                rjNumber: work.sourceId ?? '',
                 releaseDate: work.release,
               ),
               WorkInfo(work: work),

--- a/lib/widgets/detail/work_cover.dart
+++ b/lib/widgets/detail/work_cover.dart
@@ -3,12 +3,15 @@ import 'package:cached_network_image/cached_network_image.dart';
 
 class WorkCover extends StatelessWidget {
   final String imageUrl;
+  final int workId;
   final String sourceId;
   final String? releaseDate;
+
 
   const WorkCover({
     super.key,
     required this.imageUrl,
+    required this.workId,
     required this.sourceId,
     this.releaseDate,
   });
@@ -20,7 +23,7 @@ class WorkCover extends StatelessWidget {
         AspectRatio(
           aspectRatio: 195 / 146,
           child: Hero(
-            tag: 'work-cover-$sourceId',
+            tag: 'work-cover-$workId',
             child: CachedNetworkImage(
               imageUrl: imageUrl,
               fit: BoxFit.cover,

--- a/lib/widgets/detail/work_cover.dart
+++ b/lib/widgets/detail/work_cover.dart
@@ -3,13 +3,13 @@ import 'package:cached_network_image/cached_network_image.dart';
 
 class WorkCover extends StatelessWidget {
   final String imageUrl;
-  final String rjNumber;
+  final String sourceId;
   final String? releaseDate;
 
   const WorkCover({
     super.key,
     required this.imageUrl,
-    required this.rjNumber,
+    required this.sourceId,
     this.releaseDate,
   });
 
@@ -20,7 +20,7 @@ class WorkCover extends StatelessWidget {
         AspectRatio(
           aspectRatio: 195 / 146,
           child: Hero(
-            tag: 'work-cover-$rjNumber',
+            tag: 'work-cover-$sourceId',
             child: CachedNetworkImage(
               imageUrl: imageUrl,
               fit: BoxFit.cover,
@@ -39,7 +39,7 @@ class WorkCover extends StatelessWidget {
               borderRadius: BorderRadius.circular(4),
             ),
             child: Text(
-              rjNumber,
+              sourceId,
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Colors.white,
                     fontSize: 12,

--- a/lib/widgets/work_card/components/work_cover_image.dart
+++ b/lib/widgets/work_card/components/work_cover_image.dart
@@ -4,14 +4,14 @@ import 'package:shimmer/shimmer.dart';
 
 class WorkCoverImage extends StatelessWidget {
   final String imageUrl;
-  final String rjNumber;
+  final String sourceId;
   // 195/146 ≈ 1.336
   static const double _aspectRatio = 195 / 146;
 
   const WorkCoverImage({
     super.key,
     required this.imageUrl,
-    required this.rjNumber,
+    required this.sourceId,
   });
 
   @override
@@ -21,7 +21,7 @@ class WorkCoverImage extends StatelessWidget {
       child: Stack(
         children: [
           Hero(
-            tag: 'work-cover-$rjNumber',
+            tag: 'work-cover-$sourceId',
             child: CachedNetworkImage(
               imageUrl: imageUrl,
               fit: BoxFit.cover,
@@ -56,7 +56,7 @@ class WorkCoverImage extends StatelessWidget {
                 borderRadius: BorderRadius.circular(4),
               ),
               child: Text(
-                rjNumber,
+                sourceId,
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Colors.white,
                       fontSize: 12,

--- a/lib/widgets/work_card/components/work_cover_image.dart
+++ b/lib/widgets/work_card/components/work_cover_image.dart
@@ -4,6 +4,7 @@ import 'package:shimmer/shimmer.dart';
 
 class WorkCoverImage extends StatelessWidget {
   final String imageUrl;
+  final int workId;
   final String sourceId;
   // 195/146 ≈ 1.336
   static const double _aspectRatio = 195 / 146;
@@ -11,6 +12,7 @@ class WorkCoverImage extends StatelessWidget {
   const WorkCoverImage({
     super.key,
     required this.imageUrl,
+    required this.workId,
     required this.sourceId,
   });
 
@@ -21,7 +23,7 @@ class WorkCoverImage extends StatelessWidget {
       child: Stack(
         children: [
           Hero(
-            tag: 'work-cover-$sourceId',
+            tag: 'work-cover-$workId',
             child: CachedNetworkImage(
               imageUrl: imageUrl,
               fit: BoxFit.cover,

--- a/lib/widgets/work_card/work_card.dart
+++ b/lib/widgets/work_card/work_card.dart
@@ -30,7 +30,7 @@ class WorkCard extends StatelessWidget {
           children: [
             WorkCoverImage(
               imageUrl: work.mainCoverUrl ?? '',
-              rjNumber: 'RJ${work.id ?? 0}',
+              rjNumber: work.sourceId ?? '',
             ),
             Expanded(
               child: WorkInfoSection(work: work),

--- a/lib/widgets/work_card/work_card.dart
+++ b/lib/widgets/work_card/work_card.dart
@@ -30,7 +30,7 @@ class WorkCard extends StatelessWidget {
           children: [
             WorkCoverImage(
               imageUrl: work.mainCoverUrl ?? '',
-              rjNumber: work.sourceId ?? '',
+              sourceId: work.sourceId ?? '',
             ),
             Expanded(
               child: WorkInfoSection(work: work),

--- a/lib/widgets/work_card/work_card.dart
+++ b/lib/widgets/work_card/work_card.dart
@@ -30,6 +30,7 @@ class WorkCard extends StatelessWidget {
           children: [
             WorkCoverImage(
               imageUrl: work.mainCoverUrl ?? '',
+              workId: work.id ?? 0,
               sourceId: work.sourceId ?? '',
             ),
             Expanded(


### PR DESCRIPTION
1. 对于 Dlsite 的 RJ 号，不足 6/8 位应当在前面补 0，变成 6/8 位
 问题示例：
   <img width="103" alt="image" src="https://github.com/user-attachments/assets/edd284a8-1210-4b1b-8643-fdc55a54fe81" />

    应显示：
      <img width="84" alt="image" src="https://github.com/user-attachments/assets/a4c93f9c-67dd-40a7-bb87-f189304601c0" />

2. work.id 并不等于 rj 号，这是历史遗留问题，详见 tg 消息 https://t.me/asmr_one_chan/67
  问题示例：
   <img width="313" alt="image" src="https://github.com/user-attachments/assets/965254ad-c277-4357-8d3d-3337152fb3b4" />

3. 对于 asmr.one，上述两个逻辑不应由客户端完成，直接引用 work.sourceId 字段即可

4. sourceId 并不唯一，对于需要标签唯一的 Hero tag，应该使用 workId
考虑边界情况：同一部作品，两个不同版本，他俩 sourceId 相同，同时显示在作品列表里

5. 统一变量命名，rjNumber 并不通用，其实还有 VJ BJ 以及将来可能会有根本不是 Dlsite 的作品


简单总结：
work.sourceId：人类可读，但不唯一，显示时用这个
work.id：机器可读，保证唯一，当功能需要确保唯一时，用这个